### PR TITLE
Remove logilab-common from install_requires

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 coverage==4.0.3
 coveralls==1.1
-logilab-common==1.1.0
 flake8==2.5.1
 Flask==0.10.1
 Flask-WTF==0.12

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,11 @@ if sys.version_info < (2, 7):
     _install_requires += [
         'pylint>=1.0,<1.4',
         'astroid>=1.0,<1.3.0',
-        'logilab-common>=0.60.0,<0.63',
     ]
 else:
     _install_requires += [
         'pylint>=1.0',
         'astroid>=1.0',
-        'logilab-common>=0.60.0',
     ]
 
 setup(


### PR DESCRIPTION
`logilab-common` does not seem to be used anywhere in `pylint-flask`. So this PR removes `logilab-common` from `install_requires`. It also removes it from `dev-requirements.txt` since Travis and tox both succeeded without it.