### PR TITLE
Include the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include LICENSE
 graft test


### PR DESCRIPTION
Add the license to the `MANIFEST.in` to ensure it is included in packages like `sdist`s.