### PR TITLE
fix import order and run black for formatting

### DIFF
--- a/pylint_flask/__init__.py
+++ b/pylint_flask/__init__.py
@@ -1,14 +1,14 @@
-'''pylint_flask module'''
+"""pylint_flask module"""
 
-from astroid import MANAGER
-from astroid import nodes
 import re
+
+from astroid import MANAGER, nodes
 
 
 def register(_):
-    '''register is expected by pylint for plugins, but we are creating a
+    """register is expected by pylint for plugins, but we are creating a
     transform, not registering a checker.
-    '''
+    """
     pass
 
 
@@ -17,42 +17,40 @@ def copy_node_info(src, dest):
 
     Every node in the AST has to have line number information.  Get
     the information from the old stmt."""
-    for attr in ['lineno', 'fromlineno', 'tolineno',
-                 'col_offset', 'parent']:
+    for attr in ["lineno", "fromlineno", "tolineno", "col_offset", "parent"]:
         if hasattr(src, attr):
             setattr(dest, attr, getattr(src, attr))
 
 
 def mark_transformed(node):
-    '''Mark a node as transformed so we don't process it multiple times.'''
+    """Mark a node as transformed so we don't process it multiple times."""
     node.pylint_flask_was_transformed = True
 
 
 def is_transformed(node):
-    '''Return True if `node` was already transformed.'''
-    return getattr(node, 'pylint_flask_was_transformed', False)
+    """Return True if `node` was already transformed."""
+    return getattr(node, "pylint_flask_was_transformed", False)
 
 
 def make_non_magical_flask_import(flask_ext_name):
-    '''Convert a flask.ext.admin into flask_admin.'''
-    match = re.match(r'flask\.ext\.(.*)', flask_ext_name)
+    """Convert a flask.ext.admin into flask_admin."""
+    match = re.match(r"flask\.ext\.(.*)", flask_ext_name)
     if match is None:
-        raise LookupError("Module name `{}` doesn't match"
-                          "`flask.ext` style import.")
+        raise LookupError("Module name `{}` doesn't match" "`flask.ext` style import.")
     from_name = match.group(1)
-    actual_module_name = 'flask_{}'.format(from_name)
+    actual_module_name = "flask_{}".format(from_name)
     return actual_module_name
 
 
 def transform_flask_from_import(node):
-    '''Translates a flask.ext from-style import into a non-magical import.
+    """Translates a flask.ext from-style import into a non-magical import.
 
     Translates:
         from flask.ext import wtf, bcrypt as fcrypt
     Into:
         import flask_wtf as wtf, flask_bcrypt as fcrypt
 
-    '''
+    """
     new_names = []
     # node.names is a list of 2-tuples. Each tuple consists of (name, as_name).
     # So, the import would be represented as:
@@ -61,7 +59,7 @@ def transform_flask_from_import(node):
     #
     # node.names = [('wtf', 'ftw'), ('admin', None)]
     for (name, as_name) in node.names:
-        actual_module_name = 'flask_{}'.format(name)
+        actual_module_name = "flask_{}".format(name)
         new_names.append((actual_module_name, as_name or name))
 
     new_node = nodes.Import()
@@ -72,17 +70,18 @@ def transform_flask_from_import(node):
 
 
 def is_flask_from_import(node):
-    '''Predicate for checking if we have the flask module.'''
+    """Predicate for checking if we have the flask module."""
     # Check for transformation first so we don't double process
-    return not is_transformed(node) and node.modname == 'flask.ext'
+    return not is_transformed(node) and node.modname == "flask.ext"
 
-MANAGER.register_transform(nodes.ImportFrom,
-                           transform_flask_from_import,
-                           is_flask_from_import)
+
+MANAGER.register_transform(
+    nodes.ImportFrom, transform_flask_from_import, is_flask_from_import
+)
 
 
 def transform_flask_from_long(node):
-    '''Translates a flask.ext.wtf from-style import into a non-magical import.
+    """Translates a flask.ext.wtf from-style import into a non-magical import.
 
     Translates:
         from flask.ext.wtf import Form
@@ -91,7 +90,7 @@ def transform_flask_from_long(node):
         from flask_wtf import Form
         from flask_admin.model import InlineFormAdmin
 
-    '''
+    """
     actual_module_name = make_non_magical_flask_import(node.modname)
     new_node = nodes.ImportFrom(actual_module_name, node.names, node.level)
     copy_node_info(node, new_node)
@@ -100,29 +99,30 @@ def transform_flask_from_long(node):
 
 
 def is_flask_from_import_long(node):
-    '''Check if an import is like `from flask.ext.wtf import Form`.'''
+    """Check if an import is like `from flask.ext.wtf import Form`."""
     # Check for transformation first so we don't double process
-    return not is_transformed(node) and node.modname.startswith('flask.ext.')
+    return not is_transformed(node) and node.modname.startswith("flask.ext.")
 
-MANAGER.register_transform(nodes.ImportFrom,
-                           transform_flask_from_long,
-                           is_flask_from_import_long)
+
+MANAGER.register_transform(
+    nodes.ImportFrom, transform_flask_from_long, is_flask_from_import_long
+)
 
 
 def transform_flask_bare_import(node):
-    '''Translates a flask.ext.wtf bare import into a non-magical import.
+    """Translates a flask.ext.wtf bare import into a non-magical import.
 
     Translates:
         import flask.ext.admin as admin
     Into:
         import flask_admin as admin
-    '''
+    """
 
     new_names = []
     for (name, as_name) in node.names:
-        match = re.match(r'flask\.ext\.(.*)', name)
+        match = re.match(r"flask\.ext\.(.*)", name)
         from_name = match.group(1)
-        actual_module_name = 'flask_{}'.format(from_name)
+        actual_module_name = "flask_{}".format(from_name)
         new_names.append((actual_module_name, as_name))
 
     new_node = nodes.Import()
@@ -133,10 +133,12 @@ def transform_flask_bare_import(node):
 
 
 def is_flask_bare_import(node):
-    '''Check if an import is like `import flask.ext.admin as admin`.'''
-    return (not is_transformed(node) and
-            any(['flask.ext' in pair[0] for pair in node.names]))
+    """Check if an import is like `import flask.ext.admin as admin`."""
+    return not is_transformed(node) and any(
+        ["flask.ext" in pair[0] for pair in node.names]
+    )
 
-MANAGER.register_transform(nodes.Import,
-                           transform_flask_bare_import,
-                           is_flask_bare_import)
+
+MANAGER.register_transform(
+    nodes.Import, transform_flask_bare_import, is_flask_bare_import
+)


### PR DESCRIPTION
When using this plugin it ironically causes pylint to complain because astroid is
imported before re. I constantly get the following diagnositcs message
when using with vim which is fairly annoying. 

[pylint C0411] standard import "import re" should be placed before "from astroid import MANAGER" (wrong-import-order)


![Screen Shot 2021-01-07 at 1 13 25 AM](https://user-images.githubusercontent.com/20023313/103858051-a7bd3700-5085-11eb-9474-b95993d787e7.png)



Everything else besides switching the import order is just formatting from black, which I can create another pull request 
without if need be.