### PR TITLE
Removed unnecessary pass statement. Function has at least a docstring.

### DIFF
--- a/pylint_flask/__init__.py
+++ b/pylint_flask/__init__.py
@@ -9,7 +9,6 @@ def register(_):
     """register is expected by pylint for plugins, but we are creating a
     transform, not registering a checker.
     """
-    pass
 
 
 def copy_node_info(src, dest):


### PR DESCRIPTION
Removed unnecessary pass statement from __init__.py. Function has at least a docstring. A pass statement is necessary only when the function has none of the following:
- docstring;
- code.

Pylint was constantly showing warnings (in VSCode at least) on an "unnecessary pass statement" on line 12 in __init__.py.